### PR TITLE
Only tag stats with query when enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.5.3
+FROM golang:1.7.0
 
 RUN apt-get update
 RUN apt-get install -y libpcap-dev
 COPY . /go/src/github.com/remind101/dnsdog
-RUN GO15VENDOREXPERIMENT=1 go install github.com/remind101/dnsdog/cmd/...
+RUN go install github.com/remind101/dnsdog/cmd/...

--- a/cmd/dnsdog/main.go
+++ b/cmd/dnsdog/main.go
@@ -9,11 +9,12 @@ import (
 
 func main() {
 	var (
-		iface = flag.String("iface", "eth0", "Interface to listen on")
-		addr  = flag.String("statsd", "127.0.0.1:8125", "Statsd address")
+		iface        = flag.String("iface", "eth0", "Interface to listen on")
+		addr         = flag.String("statsd", "127.0.0.1:8125", "Statsd address")
+		includeQuery = flag.Bool("query", false, "Whether to include query strings in stats, defaults to false.")
 	)
 	flag.Parse()
-	if err := dnsdog.Watch(*iface, *addr); err != nil {
+	if err := dnsdog.Watch(*iface, *addr, *includeQuery); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
This gives dnsdog a CLI flag that enables whether or not it should tag
its stats with the query (ie: the hostname of the DNS packet), and
disables this feature by default. This should cut down on the
cardinality of our dns stats, which is quite high right now.